### PR TITLE
Add: Stateful Python random generator API

### DIFF
--- a/include/numkong/numkong.h
+++ b/include/numkong/numkong.h
@@ -29,6 +29,7 @@
 #include "numkong/spatials.h"     // Batched Angular & Euclidean distances, like `nk_angulars_packed_f32`
 #include "numkong/maxsim.h"       // MaxSim: Multi-Vector Maximum Similarity, like `nk_maxsim_packed_f32`
 #include "numkong/trigonometry.h" // Sin, Cos, Atan, like `nk_each_sin_f64`
+#include "numkong/random.h"       // Stateful pseudo-random number generation
 
 #if defined(__cplusplus)
 extern "C" {

--- a/include/numkong/random.h
+++ b/include/numkong/random.h
@@ -36,12 +36,67 @@
 #ifndef NK_RANDOM_H
 #define NK_RANDOM_H
 
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include "numkong/types.h"
 #include "numkong/cast.h"
 
 #if defined(__cplusplus)
 extern "C" {
 #endif // defined(__cplusplus)
+
+/** @brief Stateful generator used by the language bindings and native callers. */
+typedef struct nk_random_generator_t {
+    uint64_t state;
+} nk_random_generator_t;
+
+/** @brief Initialize a generator from an explicit seed. */
+NK_PUBLIC void nk_random_seed(nk_random_generator_t *generator, uint64_t seed) {
+    generator->state = seed;
+}
+
+/** @brief Advance the generator and return a deterministic 64-bit value. */
+NK_PUBLIC uint64_t nk_random_next_u64(nk_random_generator_t *generator) {
+    uint64_t value = (generator->state += UINT64_C(0x9E3779B97F4A7C15));
+    value = (value ^ (value >> 30)) * UINT64_C(0xBF58476D1CE4E5B9);
+    value = (value ^ (value >> 27)) * UINT64_C(0x94D049BB133111EB);
+    return value ^ (value >> 31);
+}
+
+/** @brief Return a uniformly distributed double in [0, 1). */
+NK_PUBLIC double nk_random_uniform_f64(nk_random_generator_t *generator) {
+    return (double)(nk_random_next_u64(generator) >> 11) * 0x1.0p-53;
+}
+
+/** @brief Return a uniformly distributed float in [0, 1). */
+NK_PUBLIC float nk_random_uniform_f32(nk_random_generator_t *generator) {
+    return (float)((double)(nk_random_next_u64(generator) >> 40) * 0x1.0p-24);
+}
+
+/** @brief Return a uniformly distributed integer in [0, bound). */
+NK_PUBLIC uint64_t nk_random_bounded_u64(nk_random_generator_t *generator, uint64_t bound) {
+    if (!bound) return nk_random_next_u64(generator);
+    uint64_t const threshold = (uint64_t)(0 - bound) % bound;
+    uint64_t value;
+    do { value = nk_random_next_u64(generator); } while (value < threshold);
+    return value % bound;
+}
+
+/** @brief Return a standard normal sample using the Box-Muller transform. */
+NK_PUBLIC double nk_random_standard_normal_f64(nk_random_generator_t *generator) {
+    double const first = ((double)(nk_random_next_u64(generator) >> 11) + 1.0) * 0x1.0p-53;
+    double const second = nk_random_uniform_f64(generator);
+    double const radius = sqrt(-2.0 * log(first));
+    double const angle = 2.0 * 3.14159265358979323846264338327950288 * second;
+    return radius * cos(angle);
+}
+
+/** @brief Return a normal sample with the requested location and scale. */
+NK_PUBLIC double nk_random_normal_f64(nk_random_generator_t *generator, double location, double scale) {
+    return location + scale * nk_random_standard_normal_f64(generator);
+}
 
 #if defined(__cplusplus)
 } // extern "C"

--- a/python/README.md
+++ b/python/README.md
@@ -32,6 +32,31 @@ dot = nk.dot(a, b)  # widened accumulation, not same-dtype
 print(dot)
 ```
 
+## Stateful Random Generation
+
+`nk.Generator` provides an independent, reproducible source of random values for pipelines that must not share
+process-global random state. The first API phase supports `random`, `uniform`, `normal`, `standard_normal`, and
+`integers`. Every method accepts `size` as an integer or tuple, `dtype=`, and a writable C-contiguous `out=` buffer.
+
+```python
+import numkong as nk
+
+generator = nk.Generator(seed=137)
+images = generator.uniform(0.0, 1.0, size=(8, 224, 224, 3), dtype="float32")
+labels = generator.integers(0, 10, size=32, dtype="int32")
+
+same_images = nk.Generator(seed=137).uniform(0.0, 1.0, size=(8, 224, 224, 3), dtype="float32")
+assert images == same_images
+```
+
+The generator owns its state, releases the GIL while filling native output, and returns a NumKong `Tensor` unless
+`out=` is supplied. With `out=`, the method writes in place and returns `None`; NumPy arrays, `memoryview` objects,
+and NumKong tensors are accepted when their shape, dtype, and C-contiguous layout match the request.
+
+This first phase fixes the stateful Python contract and a deterministic scalar core. It does not claim SIMD speedup
+yet; ISA-specific fill kernels and distribution extensions such as `choice`, `poisson`, `laplace`, and `beta` remain
+follow-up work.
+
 ## Installation
 
 From PyPI:

--- a/python/numkong.c
+++ b/python/numkong.c
@@ -98,6 +98,7 @@
 #include "each.h"
 #include "mesh.h"
 #include "maxsim.h"
+#include "random.h"
 #include "numpy_interop.h"
 #include "dlpack_interop.h"
 
@@ -1212,6 +1213,7 @@ PyMODINIT_FUNC PyInit__numkong(void) {
     if (PyType_Ready(&PackedMatrixType) < 0) return NULL;
     if (PyType_Ready(&MaxSimPackedMatrixType) < 0) return NULL;
     if (PyType_Ready(&MeshAlignmentResultType) < 0) return NULL;
+    if (PyType_Ready(&RandomGeneratorType) < 0) return NULL;
 
     m = PyModule_Create(&nk_module);
     if (m == NULL) return NULL;
@@ -1260,6 +1262,14 @@ PyMODINIT_FUNC PyInit__numkong(void) {
     Py_INCREF(&MeshAlignmentResultType);
     if (PyModule_AddObject(m, "MeshAlignmentResult", (PyObject *)&MeshAlignmentResultType) < 0) {
         Py_XDECREF(&MeshAlignmentResultType);
+        Py_XDECREF(m);
+        return NULL;
+    }
+
+    // Register the stateful random generator type.
+    Py_INCREF(&RandomGeneratorType);
+    if (PyModule_AddObject(m, "Generator", (PyObject *)&RandomGeneratorType) < 0) {
+        Py_XDECREF(&RandomGeneratorType);
         Py_XDECREF(m);
         return NULL;
     }

--- a/python/numkong/__init__.pyi
+++ b/python/numkong/__init__.pyi
@@ -369,6 +369,78 @@ class Tensor(memoryview):
         """Return the index of the maximum element, or None if all elements are NaN."""
         ...
 
+
+class Generator:
+    """Independent stateful pseudo-random number generator."""
+
+    def __init__(self, seed: int | None = None) -> None:
+        """Create a generator with an explicit integer seed."""
+        ...
+
+    @property
+    def state(self) -> int:
+        """Read or replace the generator's reproducible state."""
+        ...
+
+    @state.setter
+    def state(self, value: int) -> None: ...
+
+    def random(
+        self,
+        size: int | tuple[int, ...],
+        *,
+        dtype: Literal["f32", "float32", "f64", "float64"] = "float32",
+        out: _BufferType | None = None,
+    ) -> Tensor | None:
+        """Generate uniform samples in [0, 1)."""
+        ...
+
+    def uniform(
+        self,
+        low: float = 0.0,
+        high: float = 1.0,
+        size: int | tuple[int, ...] = ...,
+        *,
+        dtype: Literal["f32", "float32", "f64", "float64"] = "float32",
+        out: _BufferType | None = None,
+    ) -> Tensor | None:
+        """Generate uniform samples in [low, high)."""
+        ...
+
+    def normal(
+        self,
+        loc: float = 0.0,
+        scale: float = 1.0,
+        size: int | tuple[int, ...] = ...,
+        *,
+        dtype: Literal["f32", "float32", "f64", "float64"] = "float32",
+        out: _BufferType | None = None,
+    ) -> Tensor | None:
+        """Generate normal samples with the requested location and scale."""
+        ...
+
+    def standard_normal(
+        self,
+        size: int | tuple[int, ...],
+        *,
+        dtype: Literal["f32", "float32", "f64", "float64"] = "float32",
+        out: _BufferType | None = None,
+    ) -> Tensor | None:
+        """Generate standard normal samples."""
+        ...
+
+    def integers(
+        self,
+        low: int,
+        high: int | None = None,
+        size: int | tuple[int, ...] = ...,
+        *,
+        dtype: _IntegralTypeName = "int64",
+        out: _BufferType | None = None,
+    ) -> Tensor | None:
+        """Generate uniformly distributed integers in [low, high)."""
+        ...
+
 class PackedMatrix:
     """Opaque pre-packed matrix for repeated cross operations.
 

--- a/python/random.c
+++ b/python/random.c
@@ -1,0 +1,540 @@
+/**
+ *  @brief Stateful random generator Python binding.
+ *  @file python/random.c
+ */
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include <limits.h>
+#include <math.h>
+#include <stdint.h>
+
+#include <numkong/random.h>
+
+#include "numkong.h"
+#include "random.h"
+#include "tensor.h"
+
+typedef struct {
+    PyObject_HEAD
+    nk_random_generator_t generator;
+} RandomGenerator;
+
+typedef struct {
+    Tensor *owned;
+    Py_buffer buffer;
+    nk_buffer_backing_t backing;
+    char *data;
+    int has_buffer;
+} RandomOutput;
+
+static int keyword_allowed(PyObject *name, char const *const *allowed) {
+    for (size_t i = 0; allowed[i]; ++i)
+        if (PyUnicode_CompareWithASCIIString(name, allowed[i]) == 0) return 1;
+    return 0;
+}
+
+static int reject_unknown_keywords(PyObject *kwnames, char const *const *allowed, char const *function_name) {
+    Py_ssize_t const keyword_count = kwnames ? PyTuple_GET_SIZE(kwnames) : 0;
+    for (Py_ssize_t i = 0; i < keyword_count; ++i) {
+        PyObject *name = PyTuple_GET_ITEM(kwnames, i);
+        if (!keyword_allowed(name, allowed)) {
+            PyErr_Format(PyExc_TypeError, "%s() unexpected keyword: %S", function_name, name);
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int get_argument(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames, Py_ssize_t position,
+                        char const *name, PyObject *default_value, PyObject **value) {
+    int found = 0;
+    if (nargs > position) {
+        *value = args[position];
+        found = 1;
+    }
+
+    Py_ssize_t const keyword_count = kwnames ? PyTuple_GET_SIZE(kwnames) : 0;
+    for (Py_ssize_t i = 0; i < keyword_count; ++i) {
+        PyObject *keyword = PyTuple_GET_ITEM(kwnames, i);
+        if (PyUnicode_CompareWithASCIIString(keyword, name) != 0) continue;
+        if (found) {
+            PyErr_Format(PyExc_TypeError, "got multiple values for argument '%s'", name);
+            return 0;
+        }
+        *value = args[nargs + i];
+        found = 1;
+    }
+
+    if (!found) *value = default_value;
+    return 1;
+}
+
+static int parse_shape(PyObject *size_obj, Py_ssize_t *shape, size_t *rank) {
+    if (size_obj == NULL || size_obj == Py_None) {
+        PyErr_SetString(PyExc_TypeError, "size must be an int or tuple of ints");
+        return 0;
+    }
+    if (PyLong_Check(size_obj)) {
+        shape[0] = PyLong_AsSsize_t(size_obj);
+        if (PyErr_Occurred()) return 0;
+        if (shape[0] < 0) {
+            PyErr_SetString(PyExc_ValueError, "size dimensions must be non-negative");
+            return 0;
+        }
+        *rank = 1;
+        return 1;
+    }
+    if (!PyTuple_Check(size_obj)) {
+        PyErr_SetString(PyExc_TypeError, "size must be an int or tuple of ints");
+        return 0;
+    }
+
+    Py_ssize_t const dimensions = PyTuple_GET_SIZE(size_obj);
+    if (dimensions > NK_TENSOR_MAX_RANK) {
+        PyErr_Format(PyExc_ValueError, "size has %zd dimensions, max is %d", dimensions, NK_TENSOR_MAX_RANK);
+        return 0;
+    }
+    for (Py_ssize_t i = 0; i < dimensions; ++i) {
+        PyObject *dimension = PyTuple_GET_ITEM(size_obj, i);
+        if (!PyLong_Check(dimension)) {
+            PyErr_SetString(PyExc_TypeError, "size dimensions must be integers");
+            return 0;
+        }
+        shape[i] = PyLong_AsSsize_t(dimension);
+        if (PyErr_Occurred()) return 0;
+        if (shape[i] < 0) {
+            PyErr_SetString(PyExc_ValueError, "size dimensions must be non-negative");
+            return 0;
+        }
+    }
+    *rank = (size_t)dimensions;
+    return 1;
+}
+
+static int count_elements(Py_ssize_t const *shape, size_t rank, size_t *total) {
+    size_t count = 1;
+    for (size_t i = 0; i < rank; ++i) {
+        if ((size_t)shape[i] && count > SIZE_MAX / (size_t)shape[i]) {
+            PyErr_SetString(PyExc_OverflowError, "size is too large");
+            return 0;
+        }
+        count *= (size_t)shape[i];
+    }
+    *total = count;
+    return 1;
+}
+
+static int parse_dtype(PyObject *dtype_obj, nk_dtype_t default_dtype, nk_dtype_t *dtype) {
+    *dtype = dtype_obj ? py_object_to_nk_dtype(dtype_obj) : default_dtype;
+    if (*dtype == nk_dtype_unknown_k) return 0;
+    return 1;
+}
+
+static int parse_f64(PyObject *object, double *value, char const *name) {
+    if (!object) {
+        PyErr_Format(PyExc_TypeError, "%s is required", name);
+        return 0;
+    }
+    *value = PyFloat_AsDouble(object);
+    if (PyErr_Occurred()) {
+        PyErr_Clear();
+        PyErr_Format(PyExc_TypeError, "%s must be a real number", name);
+        return 0;
+    }
+    return 1;
+}
+
+static int parse_i64(PyObject *object, int64_t *value, char const *name) {
+    if (!object || !PyLong_Check(object)) {
+        PyErr_Format(PyExc_TypeError, "%s must be an integer", name);
+        return 0;
+    }
+    *value = PyLong_AsLongLong(object);
+    if (PyErr_Occurred()) {
+        PyErr_Clear();
+        PyErr_Format(PyExc_OverflowError, "%s does not fit in int64", name);
+        return 0;
+    }
+    return 1;
+}
+
+static int prepare_output(RandomOutput *output, PyObject *out_obj, nk_dtype_t dtype, size_t rank,
+                          Py_ssize_t const *shape) {
+    output->owned = NULL;
+    output->has_buffer = 0;
+    if (out_obj == NULL || out_obj == Py_None) {
+        output->owned = Tensor_new(dtype, rank, shape);
+        if (!output->owned) return 0;
+        output->data = output->owned->data;
+        return 1;
+    }
+
+    if (!nk_get_buffer(out_obj, &output->buffer, PyBUF_STRIDES | PyBUF_FORMAT | PyBUF_WRITABLE, &output->backing))
+        return 0;
+    output->has_buffer = 1;
+
+    nk_dtype_t const out_dtype = resolve_nk_dtype_in_py_buffer(&output->buffer);
+    if (out_dtype != dtype) {
+        PyErr_Format(PyExc_TypeError, "out dtype '%s' does not match requested '%s'", nk_dtype_name(out_dtype),
+                     nk_dtype_name(dtype));
+        return 0;
+    }
+    if ((size_t)output->buffer.ndim != rank) {
+        PyErr_Format(PyExc_ValueError, "out rank %d does not match requested rank %zu", output->buffer.ndim, rank);
+        return 0;
+    }
+    for (size_t i = 0; i < rank; ++i) {
+        if (output->buffer.shape[i] != shape[i]) {
+            PyErr_Format(PyExc_ValueError, "out shape does not match size at dimension %zu", i);
+            return 0;
+        }
+    }
+    if (!PyBuffer_IsContiguous(&output->buffer, 'C')) {
+        PyErr_SetString(PyExc_ValueError, "out must be C-contiguous");
+        return 0;
+    }
+    output->data = (char *)output->buffer.buf;
+    return 1;
+}
+
+static void release_output(RandomOutput *output) {
+    if (output->has_buffer) PyBuffer_Release(&output->buffer);
+    Py_XDECREF(output->owned);
+}
+
+static PyObject *finish_output(RandomOutput *output) {
+    if (output->has_buffer) {
+        PyBuffer_Release(&output->buffer);
+        output->has_buffer = 0;
+        Py_RETURN_NONE;
+    }
+    return (PyObject *)output->owned;
+}
+
+static int floating_dtype(nk_dtype_t dtype) { return dtype == nk_f32_k || dtype == nk_f64_k; }
+
+static int integer_dtype(nk_dtype_t dtype) {
+    switch (dtype) {
+    case nk_i8_k:
+    case nk_i16_k:
+    case nk_i32_k:
+    case nk_i64_k:
+    case nk_u8_k:
+    case nk_u16_k:
+    case nk_u32_k:
+    case nk_u64_k: return 1;
+    default: return 0;
+    }
+}
+
+static int validate_integer_bounds(nk_dtype_t dtype, int64_t low, int64_t high) {
+    int64_t minimum = INT64_MIN, maximum_exclusive = INT64_MAX;
+    switch (dtype) {
+    case nk_i8_k: minimum = INT8_MIN, maximum_exclusive = INT8_MAX + 1; break;
+    case nk_i16_k: minimum = INT16_MIN, maximum_exclusive = INT16_MAX + 1; break;
+    case nk_i32_k: minimum = INT32_MIN, maximum_exclusive = (int64_t)INT32_MAX + 1; break;
+    case nk_u8_k: minimum = 0, maximum_exclusive = UINT8_MAX + 1; break;
+    case nk_u16_k: minimum = 0, maximum_exclusive = UINT16_MAX + 1; break;
+    case nk_u32_k: minimum = 0, maximum_exclusive = (int64_t)UINT32_MAX + 1; break;
+    case nk_u64_k: minimum = 0, maximum_exclusive = INT64_MAX; break;
+    case nk_i64_k: break;
+    default: return 0;
+    }
+    if (low < minimum || high > maximum_exclusive) {
+        PyErr_Format(PyExc_ValueError, "integer bounds do not fit dtype '%s'", nk_dtype_name(dtype));
+        return 0;
+    }
+    return 1;
+}
+
+static void fill_uniform(RandomGenerator *generator, char *data, nk_dtype_t dtype, size_t total, double low,
+                         double high) {
+    if (dtype == nk_f32_k) {
+        float *values = (float *)data;
+        float const lower = (float)low;
+        float const width = (float)(high - low);
+        for (size_t i = 0; i < total; ++i)
+            values[i] = lower + width * nk_random_uniform_f32(&generator->generator);
+    }
+    else {
+        double *values = (double *)data;
+        for (size_t i = 0; i < total; ++i) values[i] = low + (high - low) * nk_random_uniform_f64(&generator->generator);
+    }
+}
+
+static void fill_normal(RandomGenerator *generator, char *data, nk_dtype_t dtype, size_t total, double location,
+                        double scale) {
+    if (dtype == nk_f32_k) {
+        float *values = (float *)data;
+        for (size_t i = 0; i < total; ++i)
+            values[i] = (float)nk_random_normal_f64(&generator->generator, location, scale);
+    }
+    else {
+        double *values = (double *)data;
+        for (size_t i = 0; i < total; ++i) values[i] = nk_random_normal_f64(&generator->generator, location, scale);
+    }
+}
+
+static void write_integer(char *data, nk_dtype_t dtype, size_t index, uint64_t value) {
+    switch (dtype) {
+    case nk_i8_k: ((int8_t *)data)[index] = (int8_t)value; break;
+    case nk_i16_k: ((int16_t *)data)[index] = (int16_t)value; break;
+    case nk_i32_k: ((int32_t *)data)[index] = (int32_t)value; break;
+    case nk_i64_k: ((int64_t *)data)[index] = (int64_t)value; break;
+    case nk_u8_k: ((uint8_t *)data)[index] = (uint8_t)value; break;
+    case nk_u16_k: ((uint16_t *)data)[index] = (uint16_t)value; break;
+    case nk_u32_k: ((uint32_t *)data)[index] = (uint32_t)value; break;
+    case nk_u64_k: ((uint64_t *)data)[index] = value; break;
+    default: break;
+    }
+}
+
+static void fill_integers(RandomGenerator *generator, char *data, nk_dtype_t dtype, size_t total, int64_t low,
+                          int64_t high) {
+    uint64_t const bound = (uint64_t)high - (uint64_t)low;
+    uint64_t const low_bits = (uint64_t)low;
+    for (size_t i = 0; i < total; ++i)
+        write_integer(data, dtype, i, low_bits + nk_random_bounded_u64(&generator->generator, bound));
+}
+
+static PyObject *generator_random(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames) {
+    static char const *const allowed[] = {"size", "dtype", "out", NULL};
+    if (nargs > 1 || !reject_unknown_keywords(kwnames, allowed, "Generator.random")) return NULL;
+
+    PyObject *size_obj = NULL, *dtype_obj = NULL, *out_obj = NULL;
+    if (!get_argument(args, nargs, kwnames, 0, "size", NULL, &size_obj) ||
+        !get_argument(args, nargs, kwnames, 1, "dtype", NULL, &dtype_obj) ||
+        !get_argument(args, nargs, kwnames, 2, "out", NULL, &out_obj))
+        return NULL;
+
+    Py_ssize_t shape[NK_TENSOR_MAX_RANK];
+    size_t rank, total;
+    if (!parse_shape(size_obj, shape, &rank) || !count_elements(shape, rank, &total)) return NULL;
+    nk_dtype_t dtype;
+    if (!parse_dtype(dtype_obj, nk_f32_k, &dtype)) return NULL;
+    if (!floating_dtype(dtype))
+        return (PyErr_Format(PyExc_TypeError, "random only supports float32 and float64"), NULL);
+
+    RandomOutput output;
+    if (!prepare_output(&output, out_obj, dtype, rank, shape)) {
+        release_output(&output);
+        return NULL;
+    }
+    PyThreadState *gil = PyEval_SaveThread();
+    fill_uniform((RandomGenerator *)self, output.data, dtype, total, 0.0, 1.0);
+    PyEval_RestoreThread(gil);
+    return finish_output(&output);
+}
+
+static PyObject *generator_uniform(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames) {
+    static char const *const allowed[] = {"low", "high", "size", "dtype", "out", NULL};
+    if (nargs > 3 || !reject_unknown_keywords(kwnames, allowed, "Generator.uniform")) return NULL;
+
+    PyObject *low_obj = NULL, *high_obj = NULL, *size_obj = NULL, *dtype_obj = NULL, *out_obj = NULL;
+    if (!get_argument(args, nargs, kwnames, 0, "low", NULL, &low_obj) ||
+        !get_argument(args, nargs, kwnames, 1, "high", NULL, &high_obj) ||
+        !get_argument(args, nargs, kwnames, 2, "size", NULL, &size_obj) ||
+        !get_argument(args, nargs, kwnames, 3, "dtype", NULL, &dtype_obj) ||
+        !get_argument(args, nargs, kwnames, 4, "out", NULL, &out_obj))
+        return NULL;
+    double low, high;
+    if (!low_obj) low = 0.0;
+    if (!high_obj) high = 1.0;
+    if ((low_obj && !parse_f64(low_obj, &low, "low")) || (high_obj && !parse_f64(high_obj, &high, "high")))
+        return NULL;
+    if (!isfinite(low) || !isfinite(high) || low >= high)
+        return (PyErr_SetString(PyExc_ValueError, "uniform requires finite low < high"), NULL);
+
+    Py_ssize_t shape[NK_TENSOR_MAX_RANK];
+    size_t rank, total;
+    if (!parse_shape(size_obj, shape, &rank) || !count_elements(shape, rank, &total)) return NULL;
+    nk_dtype_t dtype;
+    if (!parse_dtype(dtype_obj, nk_f32_k, &dtype)) return NULL;
+    if (!floating_dtype(dtype))
+        return (PyErr_Format(PyExc_TypeError, "uniform only supports float32 and float64"), NULL);
+
+    RandomOutput output;
+    if (!prepare_output(&output, out_obj, dtype, rank, shape)) {
+        release_output(&output);
+        return NULL;
+    }
+    PyThreadState *gil = PyEval_SaveThread();
+    fill_uniform((RandomGenerator *)self, output.data, dtype, total, low, high);
+    PyEval_RestoreThread(gil);
+    return finish_output(&output);
+}
+
+static PyObject *generator_normal(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames) {
+    static char const *const allowed[] = {"loc", "scale", "size", "dtype", "out", NULL};
+    if (nargs > 3 || !reject_unknown_keywords(kwnames, allowed, "Generator.normal")) return NULL;
+
+    PyObject *location_obj = NULL, *scale_obj = NULL, *size_obj = NULL, *dtype_obj = NULL, *out_obj = NULL;
+    if (!get_argument(args, nargs, kwnames, 0, "loc", NULL, &location_obj) ||
+        !get_argument(args, nargs, kwnames, 1, "scale", NULL, &scale_obj) ||
+        !get_argument(args, nargs, kwnames, 2, "size", NULL, &size_obj) ||
+        !get_argument(args, nargs, kwnames, 3, "dtype", NULL, &dtype_obj) ||
+        !get_argument(args, nargs, kwnames, 4, "out", NULL, &out_obj))
+        return NULL;
+    double location, scale;
+    if (location_obj) {
+        if (!parse_f64(location_obj, &location, "loc")) return NULL;
+    }
+    else location = 0.0;
+    if (scale_obj) {
+        if (!parse_f64(scale_obj, &scale, "scale")) return NULL;
+    }
+    else scale = 1.0;
+    if (!isfinite(location) || !isfinite(scale) || scale < 0)
+        return (PyErr_SetString(PyExc_ValueError, "normal requires finite loc and scale >= 0"), NULL);
+
+    Py_ssize_t shape[NK_TENSOR_MAX_RANK];
+    size_t rank, total;
+    if (!parse_shape(size_obj, shape, &rank) || !count_elements(shape, rank, &total)) return NULL;
+    nk_dtype_t dtype;
+    if (!parse_dtype(dtype_obj, nk_f32_k, &dtype)) return NULL;
+    if (!floating_dtype(dtype))
+        return (PyErr_Format(PyExc_TypeError, "normal only supports float32 and float64"), NULL);
+
+    RandomOutput output;
+    if (!prepare_output(&output, out_obj, dtype, rank, shape)) {
+        release_output(&output);
+        return NULL;
+    }
+    PyThreadState *gil = PyEval_SaveThread();
+    fill_normal((RandomGenerator *)self, output.data, dtype, total, location, scale);
+    PyEval_RestoreThread(gil);
+    return finish_output(&output);
+}
+
+static PyObject *generator_standard_normal(PyObject *self, PyObject *const *args, Py_ssize_t nargs,
+                                           PyObject *kwnames) {
+    static char const *const allowed[] = {"size", "dtype", "out", NULL};
+    if (nargs > 1 || !reject_unknown_keywords(kwnames, allowed, "Generator.standard_normal")) return NULL;
+
+    PyObject *size_obj = NULL, *dtype_obj = NULL, *out_obj = NULL;
+    if (!get_argument(args, nargs, kwnames, 0, "size", NULL, &size_obj) ||
+        !get_argument(args, nargs, kwnames, 1, "dtype", NULL, &dtype_obj) ||
+        !get_argument(args, nargs, kwnames, 2, "out", NULL, &out_obj))
+        return NULL;
+
+    Py_ssize_t shape[NK_TENSOR_MAX_RANK];
+    size_t rank, total;
+    if (!parse_shape(size_obj, shape, &rank) || !count_elements(shape, rank, &total)) return NULL;
+    nk_dtype_t dtype;
+    if (!parse_dtype(dtype_obj, nk_f32_k, &dtype)) return NULL;
+    if (!floating_dtype(dtype))
+        return (PyErr_Format(PyExc_TypeError, "standard_normal only supports float32 and float64"), NULL);
+
+    RandomOutput output;
+    if (!prepare_output(&output, out_obj, dtype, rank, shape)) {
+        release_output(&output);
+        return NULL;
+    }
+    PyThreadState *gil = PyEval_SaveThread();
+    fill_normal((RandomGenerator *)self, output.data, dtype, total, 0.0, 1.0);
+    PyEval_RestoreThread(gil);
+    return finish_output(&output);
+}
+
+static PyObject *generator_integers(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames) {
+    static char const *const allowed[] = {"low", "high", "size", "dtype", "out", NULL};
+    if (nargs > 3 || !reject_unknown_keywords(kwnames, allowed, "Generator.integers")) return NULL;
+
+    PyObject *low_obj = NULL, *high_obj = NULL, *size_obj = NULL, *dtype_obj = NULL, *out_obj = NULL;
+    if (!get_argument(args, nargs, kwnames, 0, "low", NULL, &low_obj) ||
+        !get_argument(args, nargs, kwnames, 1, "high", NULL, &high_obj) ||
+        !get_argument(args, nargs, kwnames, 2, "size", NULL, &size_obj) ||
+        !get_argument(args, nargs, kwnames, 3, "dtype", NULL, &dtype_obj) ||
+        !get_argument(args, nargs, kwnames, 4, "out", NULL, &out_obj))
+        return NULL;
+    int64_t low, high;
+    if (!parse_i64(low_obj, &low, "low")) return NULL;
+    if (high_obj == NULL || high_obj == Py_None) {
+        high = low;
+        low = 0;
+    }
+    else if (!parse_i64(high_obj, &high, "high")) return NULL;
+    if (low >= high) return (PyErr_SetString(PyExc_ValueError, "integers requires low < high"), NULL);
+
+    Py_ssize_t shape[NK_TENSOR_MAX_RANK];
+    size_t rank, total;
+    if (!parse_shape(size_obj, shape, &rank) || !count_elements(shape, rank, &total)) return NULL;
+    nk_dtype_t dtype;
+    if (!parse_dtype(dtype_obj, nk_i64_k, &dtype)) return NULL;
+    if (!integer_dtype(dtype) || !validate_integer_bounds(dtype, low, high)) return NULL;
+
+    RandomOutput output;
+    if (!prepare_output(&output, out_obj, dtype, rank, shape)) {
+        release_output(&output);
+        return NULL;
+    }
+    PyThreadState *gil = PyEval_SaveThread();
+    fill_integers((RandomGenerator *)self, output.data, dtype, total, low, high);
+    PyEval_RestoreThread(gil);
+    return finish_output(&output);
+}
+
+static PyObject *generator_state_get(PyObject *self, void *closure) {
+    nk_unused_(closure);
+    return PyLong_FromUnsignedLongLong(((RandomGenerator *)self)->generator.state);
+}
+
+static int generator_state_set(PyObject *self, PyObject *value, void *closure) {
+    nk_unused_(closure);
+    if (!PyLong_Check(value)) {
+        PyErr_SetString(PyExc_TypeError, "state must be an integer");
+        return -1;
+    }
+    uint64_t const state = PyLong_AsUnsignedLongLong(value);
+    if (PyErr_Occurred()) return -1;
+    nk_random_seed(&((RandomGenerator *)self)->generator, state);
+    return 0;
+}
+
+static int RandomGenerator_init(RandomGenerator *self, PyObject *args, PyObject *kwargs) {
+    PyObject *seed_obj = NULL;
+    static char *keywords[] = {"seed", NULL};
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|O:Generator", keywords, &seed_obj)) return -1;
+    uint64_t seed = 0;
+    if (seed_obj && seed_obj != Py_None) {
+        if (!PyLong_Check(seed_obj)) {
+            PyErr_SetString(PyExc_TypeError, "seed must be an integer or None");
+            return -1;
+        }
+        seed = PyLong_AsUnsignedLongLong(seed_obj);
+        if (PyErr_Occurred()) return -1;
+    }
+    nk_random_seed(&self->generator, seed);
+    return 0;
+}
+
+static PyMethodDef RandomGenerator_methods[] = {
+    {"random", (PyCFunction)generator_random, METH_FASTCALL | METH_KEYWORDS,
+     "Generate uniform samples in [0, 1)."},
+    {"uniform", (PyCFunction)generator_uniform, METH_FASTCALL | METH_KEYWORDS,
+     "Generate uniform samples in [low, high)."},
+    {"normal", (PyCFunction)generator_normal, METH_FASTCALL | METH_KEYWORDS,
+     "Generate normal samples with the requested location and scale."},
+    {"standard_normal", (PyCFunction)generator_standard_normal, METH_FASTCALL | METH_KEYWORDS,
+     "Generate standard normal samples."},
+    {"integers", (PyCFunction)generator_integers, METH_FASTCALL | METH_KEYWORDS,
+     "Generate uniformly distributed integers in [low, high)."},
+    {NULL, NULL, 0, NULL},
+};
+
+static PyGetSetDef RandomGenerator_getset[] = {
+    {"state", generator_state_get, generator_state_set, "Current generator state.", NULL},
+    {NULL, NULL, NULL, NULL, NULL},
+};
+
+PyTypeObject RandomGeneratorType = {
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "numkong.Generator",
+    .tp_doc = "Independent stateful pseudo-random number generator.",
+    .tp_basicsize = sizeof(RandomGenerator),
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    .tp_methods = RandomGenerator_methods,
+    .tp_getset = RandomGenerator_getset,
+    .tp_init = (initproc)RandomGenerator_init,
+    .tp_new = PyType_GenericNew,
+};

--- a/python/random.h
+++ b/python/random.h
@@ -1,0 +1,12 @@
+/**
+ *  @brief Stateful random generator Python binding.
+ *  @file python/random.h
+ */
+#ifndef NK_PYTHON_RANDOM_H
+#define NK_PYTHON_RANDOM_H
+
+#include <Python.h>
+
+extern PyTypeObject RandomGeneratorType;
+
+#endif // NK_PYTHON_RANDOM_H

--- a/setup.py
+++ b/setup.py
@@ -428,6 +428,7 @@ base_sources = [
     "python/each.c",
     "python/mesh.c",
     "python/maxsim.c",
+    "python/random.c",
     "python/numpy_interop.c",
     "python/dlpack_interop.c",
     "c/numkong.c",

--- a/test/test_random.py
+++ b/test/test_random.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Tests for the stateful NumKong random generator."""
+
+import numkong as nk
+import pytest
+
+np = pytest.importorskip("numpy")
+
+
+@pytest.mark.parametrize(
+    ("method", "kwargs"),
+    [
+        ("random", {"size": (3, 4), "dtype": "float32"}),
+        ("uniform", {"low": -2.0, "high": 3.0, "size": 12, "dtype": "float64"}),
+        ("normal", {"loc": 1.0, "scale": 2.0, "size": 12, "dtype": "float32"}),
+        ("standard_normal", {"size": 12, "dtype": "float64"}),
+        ("integers", {"low": -3, "high": 7, "size": (3, 4), "dtype": "int32"}),
+    ],
+)
+def test_seed_reproduces_each_distribution(method, kwargs):
+    first = getattr(nk.Generator(137), method)(**kwargs)
+    second = getattr(nk.Generator(137), method)(**kwargs)
+
+    np.testing.assert_array_equal(np.asarray(first), np.asarray(second))
+
+
+def test_generators_have_independent_state():
+    first = nk.Generator(137)
+    second = nk.Generator(137)
+
+    first.random(8)
+    np.testing.assert_array_equal(np.asarray(second.random(8)), np.asarray(nk.Generator(137).random(8)))
+
+
+def test_state_can_restore_a_sequence():
+    generator = nk.Generator(137)
+    generator.random(5)
+    state = generator.state
+    expected = np.asarray(generator.normal(size=9, dtype="float64"))
+
+    generator.state = state
+    np.testing.assert_array_equal(expected, np.asarray(generator.normal(size=9, dtype="float64")))
+
+
+def test_outputs_cover_shapes_dtypes_and_bounds():
+    generator = nk.Generator(137)
+    uniform = np.asarray(generator.uniform(-2.0, 3.0, size=(4, 5), dtype="float32"))
+    normal = np.asarray(generator.normal(loc=4.0, scale=0.0, size=5, dtype="float64"))
+    integers = np.asarray(generator.integers(0, 8, size=100, dtype="uint8"))
+
+    assert uniform.shape == (4, 5)
+    assert uniform.dtype == np.float32
+    assert np.all(uniform >= -2.0)
+    assert np.all(uniform < 3.0)
+    np.testing.assert_array_equal(normal, np.full(5, 4.0))
+    assert integers.dtype == np.uint8
+    assert np.all((integers >= 0) & (integers < 8))
+
+
+def test_out_buffer_is_filled_in_place():
+    generator = nk.Generator(137)
+    output = np.empty((2, 3), dtype=np.float32)
+
+    assert generator.random((2, 3), out=output) is None
+    assert output.shape == (2, 3)
+    assert np.all((output >= 0.0) & (output < 1.0))
+
+
+@pytest.mark.parametrize(
+    ("call", "error"),
+    [
+        (lambda generator: generator.random(), TypeError),
+        (lambda generator: generator.uniform(3.0, 3.0, size=4), ValueError),
+        (lambda generator: generator.normal(scale=-1.0, size=4), ValueError),
+        (lambda generator: generator.integers(4, 4, size=4), ValueError),
+    ],
+)
+def test_invalid_distribution_arguments_raise(call, error):
+    with pytest.raises(error):
+        call(nk.Generator(137))
+
+
+def test_out_requires_matching_c_contiguous_buffer():
+    generator = nk.Generator(137)
+    non_contiguous = np.empty((3, 2), dtype=np.float32).T
+    wrong_dtype = np.empty((2, 3), dtype=np.float64)
+
+    with pytest.raises(ValueError, match="C-contiguous"):
+        generator.random((2, 3), out=non_contiguous)
+    with pytest.raises(TypeError, match="dtype"):
+        generator.random((2, 3), out=wrong_dtype)


### PR DESCRIPTION
## Summary

This PR implements the stateful Python API baseline proposed in [#299](https://github.com/ashvardanian/NumKong/issues/299).
It establishes an independent generator with explicit state before we add ISA-specific kernels and wider distribution
coverage.

- Adds `nk.Generator(seed=...)` with `random`, `uniform`, `normal`, `standard_normal`, and `integers`.
- Supports integer or tuple `size=`, direct `float32`/`float64` and standard integer dtypes, and writable C-contiguous
  `out=` buffers.
- Keeps generator state independent between instances and releases the GIL while filling native output.
- Exposes the scalar state transition through `include/numkong/random.h` so ISA-specific fill kernels can be added
  without changing the Python contract.
- Adds typing stubs, Python documentation, and focused API tests.

## Scope

This PR fixes the smallest useful public contract requested in the issue discussion. It deliberately does not claim
SIMD acceleration yet. The current fill path is a deterministic scalar baseline; normal floating-point samples still
follow the host `libm` implementation.

The following remain separate follow-ups: ISA-specific fill kernels, `choice`, `shuffle`, `poisson`, `laplace`, and
`beta` distributions, plus wider statistical validation.

## Benchmark plan

After the API shape is reviewed, we will add a representative benchmark to [#299](https://github.com/ashvardanian/NumKong/issues/299)
against NumPy and OpenCV. It will document the workload, dtype, shape, allocation or `out=` route, warmup, iterations,
hardware, and library versions. The comparison will measure the matching available API paths; it will not present
different random algorithms as if they produced identical sequences.

## Validation

- `python3 setup.py build_ext --inplace` — passed on macOS arm64, Python 3.9.6, Apple Clang.
- `PYTHONPATH=/private/tmp/numkong-test-deps:python python3 -m pytest test/test_random.py -q` — 14 passed.
- `ruff check python/numkong/__init__.pyi test/test_random.py` — passed.
- `clang++ -std=c++20 -Iinclude -Itest -fsyntax-only test/test.cpp` — passed.
- Local smoke benchmark after one warmup call, 8 timed iterations, `(512, 512, 3)` `float32` output:
  `nk.Generator.random`: 0.331 ms median; `numpy.random.default_rng().random`: 1.297 ms median. This is only a
  local API smoke measurement, not a cross-library benchmark or SIMD performance claim.

Refs #299
