### PR TITLE
Fix: Wrong hwprobe bit for `Zvbb` on RISC-V

### DIFF
--- a/include/numkong/capabilities.h
+++ b/include/numkong/capabilities.h
@@ -726,7 +726,7 @@ NK_PUBLIC nk_capability_t nk_capabilities_riscv64_(void) {
         if (syscall(258, pairs, 1, 0, (void *)0, 0) == 0) {
             if (pairs[0].value & (1ULL << 30)) caps |= nk_cap_rvvhalf_k;
             if (pairs[0].value & (1ULL << 54)) caps |= nk_cap_rvvbf16_k;
-            if (pairs[0].value & (1ULL << 48)) caps |= nk_cap_rvvbb_k; // Zvbb
+            if (pairs[0].value & (1ULL << 17)) caps |= nk_cap_rvvbb_k; // Zvbb
         }
     }
     return caps;


### PR DESCRIPTION
The RISC-V capability probe in `nk_capabilities_riscv64_` reads bit 48 of
`RISCV_HWPROBE_KEY_IMA_EXT_0` to detect `Zvbb`. That bit is `Zawrs`
(wait-on-reservation-set); `Zvbb` is bit 17, and has been since it appeared in
Linux 6.8:

```c
/* arch/riscv/include/uapi/asm/hwprobe.h */
#define RISCV_HWPROBE_EXT_ZVBB      _BITULL(17)
#define RISCV_HWPROBE_EXT_ZVFH      _BITULL(30)
#define RISCV_HWPROBE_EXT_ZAWRS     _BITULL(48)
#define RISCV_HWPROBE_EXT_ZVFBFWMA  _BITULL(54)
```

The two lines above it are right — `Zvfh` at 30, `Zvfbfwma` at 54 — so it looks
like an isolated typo rather than a deliberate choice.

Both directions misbehave:

- **`Zawrs` without `Zvbb`** — `nk_cap_rvvbb_k` is set, `dispatch_u1.c` selects
  `nk_dot_u1_rvvbb` / `nk_hamming_u1_rvvbb` / `nk_jaccard_u1_rvvbb`, and the
  `vcpop.v` in `nk_popcount_u8m4_rvvbb_` traps. The Sophgo SG2044 (C920 v2) is
  exactly this: its device tree declares `zawrs`, `zvfh` and `zvfbfwma`, but no
  `zvbb`. On that chip the two neighbouring lines light up correctly and only
  this one is wrong.
- **`Zvbb` without `Zawrs`** — the capability is never set and the kernels fall
  back to the SWAR popcount, the 11-instructions-versus-1 path the header
  comments mention. No CPU I know of ships this combination today, since
  RVA23U64 mandates both, so this side is currently theoretical.

## Testing

Cross-compiled with GCC 16 (`-march=rv64gcv_zvbb`) and run under
qemu-user 11.1, which gates the two extensions independently. The test calls
`nk_capabilities()` and then executes the same `vcpop.v` the `rvvbb` kernels use:

| `-cpu rv64,v=true,vlen=256,...` | before | after |
|---|---|---|
| `zawrs=true,zvbb=false` (SG2044) | reports `Zvbb`, SIGILL (exit 132) | no `Zvbb`, exit 0 |
| `zawrs=false,zvbb=true` | no `Zvbb`, SWAR fallback | reports `Zvbb`, `vcpop.v` runs, exit 0 |
| `zawrs=true,zvbb=true` (RVA23) | reports `Zvbb`, exit 0 | reports `Zvbb`, exit 0 |

The RISC-V CI job builds but never executes (`--target nk_shared`), which is
presumably why this went unnoticed. Extending the QEMU pattern already used by
the LoongArch and Power jobs would cover it, but that needs a runner with
qemu-user ≥ 10.2 for `Zawrs` to appear in hwprobe at all — happy to do it as a
separate PR if useful.