### PR TITLE
Add: Explicit truncating float-to-integer casts

### DIFF
--- a/bench/bench_cast.cpp
+++ b/bench/bench_cast.cpp
@@ -51,6 +51,10 @@ void run_cast(std::string name, cast_kernel_t kernel) {
 }
 
 void bench_cast() {
+    run_cast<nk_f32_k, nk_u8_k>("cast_truncate_f32_to_u8_serial", nk_cast_truncate_serial);
+    run_cast<nk_f64_k, nk_i64_k>("cast_truncate_f64_to_i64_serial", nk_cast_truncate_serial);
+    run_cast<nk_f32_k, nk_u8_k>("cast_truncate_f32_to_u8", nk_cast_truncate);
+    run_cast<nk_f64_k, nk_i64_k>("cast_truncate_f64_to_i64", nk_cast_truncate);
 
 #if NK_TARGET_HASWELL
     run_cast<nk_f32_k, nk_f16_k>("cast_f32_to_f16_haswell", nk_cast_haswell);

--- a/c/dispatch.h
+++ b/c/dispatch.h
@@ -402,6 +402,7 @@ typedef struct {
     nk_maxsim_packed_punned_t maxsim_packed_f16;
     // Type casting
     nk_kernel_cast_punned_t cast;
+    nk_kernel_cast_punned_t cast_truncate;
     // Scalar conversions
     void (*bf16_to_f32)(nk_bf16_t const *, nk_f32_t *);
     void (*f32_to_bf16)(nk_f32_t const *, nk_bf16_t *);

--- a/c/dispatch_other.c
+++ b/c/dispatch_other.c
@@ -45,6 +45,7 @@ void nk_dispatch_cast_find_(nk_capability_t v, nk_kernel_kind_t k, nk_kernel_pun
         }
 #endif
     if (v & nk_cap_serial_k) switch (k) {
+        case nk_kernel_cast_truncate_k: *m = (m_t)&nk_cast_truncate_serial, *c = nk_cap_serial_k; return;
         case nk_kernel_cast_k: *m = (m_t)&nk_cast_serial, *c = nk_cap_serial_k; return;
         default: break;
         }
@@ -59,6 +60,8 @@ void nk_dispatch_cast_init_(nk_capability_t caps) {
 
     // Type casting (buffer-to-buffer)
     nk_dispatch_cast_find_(caps, nk_kernel_cast_k, (nk_kernel_punned_t *)&t->cast, &used);
+
+    nk_dispatch_cast_find_(caps, nk_kernel_cast_truncate_k, (nk_kernel_punned_t *)&t->cast_truncate, &used);
 
     // Scalar conversions: bf16 ↔ f32
     t->bf16_to_f32 = &nk_bf16_to_f32_serial;

--- a/c/numkong.c
+++ b/c/numkong.c
@@ -771,6 +771,10 @@ NK_DYNAMIC void nk_cast(void const *from, nk_dtype_t from_type, nk_size_t n, voi
     nk_dispatch_table.cast(from, from_type, n, to, to_type);
 }
 
+NK_DYNAMIC void nk_cast_truncate(void const *from, nk_dtype_t from_type, nk_size_t n, void *to, nk_dtype_t to_type) {
+    nk_dispatch_table.cast_truncate(from, from_type, n, to, to_type);
+}
+
 // Forward declarations for dtype-specific dispatch initialization functions
 void nk_dispatch_f64c_init_(nk_capability_t caps);
 void nk_dispatch_f32c_init_(nk_capability_t caps);

--- a/include/numkong/capabilities.h
+++ b/include/numkong/capabilities.h
@@ -248,7 +248,8 @@ typedef enum {
     nk_kernel_maxsim_pack_k = 'l',        ///< MaxSim vector packing
     nk_kernel_maxsim_packed_k = 'T',      ///< MaxSim late-interaction computation
 
-    nk_kernel_cast_k = '-', ///< Type casting from one type to another
+    nk_kernel_cast_truncate_k = 256, ///< Truncating float-to-integer type casting
+    nk_kernel_cast_k = '-',          ///< Type casting from one type to another
 
 } nk_kernel_kind_t;
 

--- a/include/numkong/cast.h
+++ b/include/numkong/cast.h
@@ -54,6 +54,23 @@ extern "C" {
  */
 NK_DYNAMIC void nk_cast(void const *from, nk_dtype_t from_type, nk_size_t n, void *to, nk_dtype_t to_type);
 
+/**
+ *  @brief Cast real floating-point arrays to byte-or-larger integers, truncating toward zero.
+ *  @param[in] from Source array of @p n real floating-point elements.
+ *  @param[in] from_type Source dtype: f64, f32, f16, bf16, e4m3, e5m2, e2m3, or e3m2.
+ *  @param[in] n Number of elements in both arrays.
+ *  @param[out] to Non-overlapping destination array.
+ *  @param[in] to_type Signed or unsigned integer dtype of width 8, 16, 32, or 64 bits.
+ *  @note Finite values truncate toward zero and saturate to the destination range.
+ *    NaNs map to zero; infinities saturate. Unsupported dtype pairs leave output untouched.
+ *    Uses a portable serial kernel; no SIMD acceleration is currently provided.
+ */
+NK_DYNAMIC void nk_cast_truncate(void const *from, nk_dtype_t from_type, nk_size_t n, void *to, nk_dtype_t to_type);
+
+/** @copydoc nk_cast_truncate */
+NK_PUBLIC void nk_cast_truncate_serial(void const *from, nk_dtype_t from_type, nk_size_t n, void *to,
+                                       nk_dtype_t to_type);
+
 /** @copydoc nk_cast */
 NK_PUBLIC void nk_cast_serial(void const *from, nk_dtype_t from_type, nk_size_t n, void *to, nk_dtype_t to_type);
 
@@ -184,6 +201,10 @@ extern "C" {
 #endif
 
 #if !NK_DYNAMIC_DISPATCH
+
+NK_PUBLIC void nk_cast_truncate(void const *from, nk_dtype_t from_type, nk_size_t n, void *to, nk_dtype_t to_type) {
+    nk_cast_truncate_serial(from, from_type, n, to, to_type);
+}
 
 NK_PUBLIC void nk_cast(void const *from, nk_dtype_t from_type, nk_size_t n, void *to, nk_dtype_t to_type) {
 #if NK_TARGET_SAPPHIRE

--- a/include/numkong/cast/serial.h
+++ b/include/numkong/cast/serial.h
@@ -2325,6 +2325,39 @@ NK_INTERNAL int nk_scalar_buffer_from_f64(nk_f64_t const *value, nk_scalar_buffe
 #pragma GCC optimize("no-tree-vectorize", "no-tree-slp-vectorize", "no-ipa-cp-clone", "no-inline")
 #endif
 
+NK_PUBLIC void nk_cast_truncate_serial(void const *from, nk_dtype_t from_type, nk_size_t n, void *to,
+                                       nk_dtype_t to_type) {
+    nk_dtype_family_t to_family = nk_dtype_family(to_type);
+    if (nk_dtype_family(from_type) != nk_dtype_family_float_k || nk_dtype_bits(to_type) < 8 ||
+        (to_family != nk_dtype_family_int_k && to_family != nk_dtype_family_uint_k))
+        return;
+
+    nk_size_t from_stride = nk_dtype_bits(from_type) / NK_BITS_PER_BYTE;
+    nk_size_t to_stride = nk_dtype_bits(to_type) / NK_BITS_PER_BYTE;
+    nk_scalar_buffer_t buffers[NK_BITS_PER_BYTE], output_buffers[NK_BITS_PER_BYTE];
+    for (nk_size_t offset = 0; offset < n;) {
+        nk_size_t count = n - offset < NK_BITS_PER_BYTE ? n - offset : NK_BITS_PER_BYTE;
+        nk_scalar_buffers_to_f64c_((char const *)from + offset * from_stride, from_type, count, buffers);
+        for (nk_size_t i = 0; i < count; ++i) {
+            nk_f64_t number = buffers[i].f64c.real;
+            // Compare with exact powers of two before casting: the largest 64-bit integer
+            // rounds UP when represented in f64. Never cast that rounded endpoint.
+            if (to_family == nk_dtype_family_uint_k)
+                buffers[i].u64 = !(number > 0) ? 0 : number >= 18446744073709551616.0 ? NK_U64_MAX : (nk_u64_t)number;
+            else
+                buffers[i].i64 = number != number                   ? 0
+                                 : number >= 9223372036854775808.0  ? NK_I64_MAX
+                                 : number <= -9223372036854775808.0 ? NK_I64_MIN
+                                                                    : (nk_i64_t)number;
+        }
+        if (to_family == nk_dtype_family_uint_k) nk_scalar_buffers_from_u64_(buffers, output_buffers, to_type, count);
+        else nk_scalar_buffers_from_i64_(buffers, output_buffers, to_type, count);
+        // Buffer-protocol outputs need not be naturally aligned for their dtype.
+        nk_copy_bytes_((char *)to + offset * to_stride, output_buffers, count * to_stride);
+        offset += count;
+    }
+}
+
 NK_PUBLIC void nk_cast_serial(void const *from, nk_dtype_t from_type, nk_size_t n, void *to, nk_dtype_t to_type) {
     if (from_type == to_type) {
         nk_size_t size_bits = nk_dtype_bits(from_type);

--- a/python/README.md
+++ b/python/README.md
@@ -715,3 +715,21 @@ with open("data.bin", "r+b") as f:
         ctypes.c_char.from_buffer(mapping)),
         (1024,), 'float32', owner=mapping)
 ```
+
+### Truncating float-to-integer casts
+
+`nk.astype(values, "uint8", rounding="truncate", out=output)` discards fractional
+parts toward zero before saturating to the destination range. For example,
+`-1.9` becomes `-1` when casting to `int8`, and `1.9` becomes `1`.
+The default `rounding="nearest_even"` preserves ties-to-even rounding.
+Both modes map NaN to zero and saturate infinities and overflow.
+
+Truncation accepts real floating-point inputs (`float64`, `float32`, `float16`,
+`bfloat16`, and NumKong mini-floats) and signed or unsigned 8/16/32/64-bit integer
+outputs. Other pairs, including packed integer outputs and complex inputs, raise
+`ValueError`. Shapes and input strides are preserved logically; `out` must have
+the exact shape and dtype, be writable and C-contiguous, and not overlap the input.
+The supplied output is returned; omitting it allocates a Tensor.
+
+This opt-in mode uses the native `nk_cast_truncate` dispatch entry and currently
+has a portable serial implementation. `Tensor.astype` retains its existing API.

--- a/python/numkong/__init__.pyi
+++ b/python/numkong/__init__.pyi
@@ -784,6 +784,7 @@ def astype(
     dtype: _DtypeLike,
     /,
     *,
+    rounding: Literal["nearest_even", "truncate"] = "nearest_even",
     out: _BufferType | None = None,
 ) -> Tensor:
     """Cast an N-D buffer to ``dtype`` without first copying it into a Tensor.
@@ -791,6 +792,10 @@ def astype(
     A supplied ``out`` must be writable, C-contiguous, have the exact input
     shape and requested dtype, and must not overlap ``a``. Returns ``out`` when
     provided, otherwise a new Tensor.
+    ``rounding="truncate"`` discards fractions toward zero for real floating-point
+    inputs and 8/16/32/64-bit integer outputs; other dtype pairs raise ValueError.
+    The default rounds ties to even. Both modes saturate overflow/infinity and
+    map NaN to zero. Truncation currently uses a portable serial native kernel.
     """
     ...
 

--- a/python/tensor.c
+++ b/python/tensor.c
@@ -422,14 +422,14 @@ static void cast_strided_recursive(                                            /
     char const *src_data, nk_dtype_t src_dtype, Py_ssize_t const *src_strides, //
     char *dest_data, nk_dtype_t dest_dtype, Py_ssize_t const *dest_strides,    //
     size_t element_size, Py_ssize_t const *shape,                              //
-    size_t remaining_dims, size_t contiguous_tail_dims) {
+    size_t remaining_dims, size_t contiguous_tail_dims, nk_kernel_cast_punned_t cast_kernel) {
 
     // Base case: both sides pack the remaining dimensions — one operation
     if (remaining_dims <= contiguous_tail_dims) {
         size_t slice_elements = 1;
         for (size_t dimension = 0; dimension < remaining_dims; ++dimension) slice_elements *= (size_t)shape[dimension];
         if (src_dtype == dest_dtype) memcpy(dest_data, src_data, slice_elements * element_size);
-        else nk_cast(src_data, src_dtype, (nk_size_t)slice_elements, dest_data, dest_dtype);
+        else if (slice_elements) cast_kernel(src_data, src_dtype, (nk_size_t)slice_elements, dest_data, dest_dtype);
         return;
     }
 
@@ -441,7 +441,7 @@ static void cast_strided_recursive(                                            /
             src_data + signed_position * src_strides[0], src_dtype, src_strides + 1, //
             dest_data + signed_position * dest_strides[0], dest_dtype,               //
             dest_strides + 1, element_size, shape + 1,                               //
-            remaining_dims - 1, contiguous_tail_dims);
+            remaining_dims - 1, contiguous_tail_dims, cast_kernel);
     }
 }
 
@@ -462,8 +462,10 @@ static size_t jointly_contiguous_tail_dimensions(size_t rank, Py_ssize_t const *
     return contiguous_tail_dims;
 }
 
-void linearize_cast_into(char const *src_data, nk_dtype_t src_dtype, char *dest_data, nk_dtype_t dest_dtype,
-                         size_t rank, Py_ssize_t const *shape, Py_ssize_t const *strides, size_t total_elements) {
+static void linearize_cast_with_kernel(char const *src_data, nk_dtype_t src_dtype, char *dest_data,
+                                       nk_dtype_t dest_dtype, size_t rank, Py_ssize_t const *shape,
+                                       Py_ssize_t const *strides, size_t total_elements,
+                                       nk_kernel_cast_punned_t cast_kernel) {
     nk_unused_(total_elements);
     size_t const src_element_size = nk_dtype_bytes_per_value(src_dtype);
     size_t const dest_element_size = nk_dtype_bytes_per_value(dest_dtype);
@@ -474,7 +476,13 @@ void linearize_cast_into(char const *src_data, nk_dtype_t src_dtype, char *dest_
                                                                            dense_dest_strides, dest_element_size);
 
     cast_strided_recursive(src_data, src_dtype, strides, dest_data, dest_dtype, dense_dest_strides, dest_element_size,
-                           shape, rank, contiguous_tail_dims);
+                           shape, rank, contiguous_tail_dims, cast_kernel);
+}
+
+void linearize_cast_into(char const *src_data, nk_dtype_t src_dtype, char *dest_data, nk_dtype_t dest_dtype,
+                         size_t rank, Py_ssize_t const *shape, Py_ssize_t const *strides, size_t total_elements) {
+    linearize_cast_with_kernel(src_data, src_dtype, dest_data, dest_dtype, rank, shape, strides, total_elements,
+                               nk_cast);
 }
 
 void cast_into_strided(char const *src_data, nk_dtype_t src_dtype, char *dest_data, nk_dtype_t dest_dtype, size_t rank,
@@ -488,7 +496,7 @@ void cast_into_strided(char const *src_data, nk_dtype_t src_dtype, char *dest_da
         rank, shape, dense_src_strides, src_element_size, dest_strides, dest_element_size);
 
     cast_strided_recursive(src_data, src_dtype, dense_src_strides, dest_data, dest_dtype, dest_strides,
-                           dest_element_size, shape, rank, contiguous_tail_dims);
+                           dest_element_size, shape, rank, contiguous_tail_dims, nk_cast);
 }
 
 char *ensure_contiguous_buffer(char const *src_data, nk_dtype_t src_dtype, nk_dtype_t target_dtype, size_t rank,
@@ -2054,6 +2062,8 @@ char const doc_astype[] =                                                       
     "Parameters:\n"                                                                        //
     "    a: Input buffer with arbitrary rank and strides.\n"                               //
     "    dtype: Target NumKong dtype name.\n"                                              //
+    "    rounding: 'nearest_even' (default) or 'truncate'. Truncation requires real\n"     //
+    "        floats and 8/16/32/64-bit integer outputs.\n"                                 //
     "    out: Optional writable C-contiguous output buffer with the exact input shape\n"   //
     "        and requested dtype. It must not overlap `a`.\n\n"                            //
     "Returns:\n"                                                                           //
@@ -2062,22 +2072,39 @@ char const doc_astype[] =                                                       
     "Notes:\n"                                                                             //
     "    Unlike `Tensor(a).astype(dtype)`, the input is never staged through a Tensor.\n"  //
     "    Narrower floating formats round ties to even. Float-to-integer casts round\n"     //
-    "    ties to even, saturate overflow and infinity, and map NaN to zero.\n\n"           //
+    "    ties to even by default; truncate discards fractions toward zero. Both modes\n"   //
+    "    saturate overflow and infinity, and map NaN to zero.\n"                           //
+    "    Truncation uses a portable serial kernel.\n\n"                                    //
     "Signature:\n"                                                                         //
-    "    >>> def astype(a, dtype, /, *, out=None) -> Tensor: ...";
+    "    >>> def astype(a, dtype, /, *, rounding='nearest_even', out=None) -> Tensor: ...";
 
 PyObject *api_astype(PyObject *self, PyObject *const *args, Py_ssize_t const nargs, PyObject *kwnames) {
     nk_unused_(self);
     if (nargs != 2) {
-        PyErr_SetString(PyExc_TypeError, "astype(a, dtype, /, *, out=None) requires exactly two positional arguments");
+        PyErr_SetString(
+            PyExc_TypeError,
+            "astype(a, dtype, /, *, rounding='nearest_even', out=None) requires exactly two positional arguments");
         return NULL;
     }
 
     PyObject *out_obj = NULL;
+    int truncate = 0;
     Py_ssize_t const keyword_count = kwnames ? PyTuple_Size(kwnames) : 0;
     for (Py_ssize_t i = 0; i < keyword_count; ++i) {
         PyObject *name = PyTuple_GET_ITEM(kwnames, i);
         if (PyUnicode_CompareWithASCIIString(name, "out") == 0) out_obj = args[nargs + i];
+        else if (PyUnicode_CompareWithASCIIString(name, "rounding") == 0) {
+            PyObject *rounding = args[nargs + i];
+            if (!PyUnicode_Check(rounding)) {
+                PyErr_SetString(PyExc_TypeError, "rounding must be a string");
+                return NULL;
+            }
+            if (PyUnicode_CompareWithASCIIString(rounding, "truncate") == 0) truncate = 1;
+            else if (PyUnicode_CompareWithASCIIString(rounding, "nearest_even") != 0) {
+                PyErr_SetString(PyExc_ValueError, "rounding must be 'nearest_even' or 'truncate'");
+                return NULL;
+            }
+        }
         else {
             PyErr_Format(PyExc_TypeError, "astype() got an unexpected keyword argument '%S'", name);
             return NULL;
@@ -2106,6 +2133,13 @@ PyObject *api_astype(PyObject *self, PyObject *const *args, Py_ssize_t const nar
     nk_dtype_t const output_dtype = py_object_to_nk_dtype(args[1]);
     if (output_dtype == nk_dtype_unknown_k) goto cleanup;
 
+    nk_dtype_family_t output_family = nk_dtype_family(output_dtype);
+    if (truncate && (nk_dtype_family(input_dtype) != nk_dtype_family_float_k || nk_dtype_bits(output_dtype) < 8 ||
+                     (output_family != nk_dtype_family_int_k && output_family != nk_dtype_family_uint_k))) {
+        PyErr_SetString(PyExc_ValueError, "rounding='truncate' requires real floats to 8/16/32/64-bit integers");
+        goto cleanup;
+    }
+
     char *result_data = NULL;
     if (!out_obj) {
         Tensor *result = Tensor_new(output_dtype, (size_t)input_buffer.ndim, input_buffer.shape);
@@ -2126,8 +2160,9 @@ PyObject *api_astype(PyObject *self, PyObject *const *args, Py_ssize_t const nar
     for (int dim = 0; dim < input_buffer.ndim; ++dim) total_elements *= (size_t)input_buffer.shape[dim];
 
     PyThreadState *gil = PyEval_SaveThread();
-    linearize_cast_into(input_buffer.buf, input_dtype, result_data, output_dtype, (size_t)input_buffer.ndim,
-                        input_buffer.shape, input_buffer.strides, total_elements);
+    linearize_cast_with_kernel(input_buffer.buf, input_dtype, result_data, output_dtype, (size_t)input_buffer.ndim,
+                               input_buffer.shape, input_buffer.strides, total_elements,
+                               truncate ? nk_cast_truncate : nk_cast);
     PyEval_RestoreThread(gil);
 
 cleanup:

--- a/test/test_cast.cpp
+++ b/test/test_cast.cpp
@@ -37,10 +37,55 @@ error_stats_t test_cast(cast_t kernel) {
     return stats;
 }
 
+/** @brief Fixed truncation oracles, including exact endpoints that f64 cannot represent as integers. */
+error_stats_t test_cast_truncate(cast_t kernel) {
+    error_stats_t stats(comparison_family_t::exact_k);
+    nk_f64_t source[] = {-INFINITY, -129.9, -2.5, -1.9, -0.5, 0.5, 1.5, 1.9, 2.5, 127.9, 255.9, INFINITY, NAN};
+    nk_i8_t expected_signed[] = {-128, -128, -2, -1, 0, 0, 1, 1, 2, 127, 127, 127, 0};
+    nk_u8_t expected_unsigned[] = {0, 0, 0, 0, 0, 0, 1, 1, 2, 127, 255, 255, 0};
+    nk_i8_t signed_output[13] = {};
+    nk_u8_t unsigned_output[13] = {};
+    // Every prefix exercises the zero-length case and both sides of the eight-element batch boundary.
+    for (nk_size_t count = 0; count <= 13; ++count) {
+        std::fill_n(signed_output, 13, 42);
+        std::fill_n(unsigned_output, 13, 42);
+        kernel(source, nk_f64_k, count, signed_output, nk_i8_k);
+        kernel(source, nk_f64_k, count, unsigned_output, nk_u8_k);
+        for (nk_size_t i = 0; i < 13; ++i) {
+            stats.accumulate(signed_output[i], i < count ? expected_signed[i] : (nk_i8_t)42);
+            stats.accumulate(unsigned_output[i], i < count ? expected_unsigned[i] : (nk_u8_t)42);
+        }
+    }
+    nk_f64_t wide_source[] = {-INFINITY, -0x1p63, -0x1p63 + 1024, 0x1p63 - 1024, 0x1p63, 0x1p64 - 2048, 0x1p64,
+                              INFINITY,  NAN};
+    nk_i64_t wide_signed[] = {NK_I64_MIN,        NK_I64_MIN, NK_I64_MIN + 1024,
+                              NK_I64_MAX - 1023, NK_I64_MAX, NK_I64_MAX,
+                              NK_I64_MAX,        NK_I64_MAX, 0};
+    nk_u64_t wide_unsigned[] = {
+        0, 0, 0, (NK_U64_MAX >> 1) - 1023, (nk_u64_t)1 << 63, NK_U64_MAX - 2047, NK_U64_MAX, NK_U64_MAX, 0};
+    nk_i64_t signed_wide_output[9];
+    nk_u64_t unsigned_wide_output[9];
+    kernel(wide_source, nk_f64_k, 9, signed_wide_output, nk_i64_k);
+    kernel(wide_source, nk_f64_k, 9, unsigned_wide_output, nk_u64_k);
+    for (nk_size_t i = 0; i < 9; ++i) {
+        // Compare as booleans so the stats accumulator cannot round adjacent 64-bit integers together.
+        stats.accumulate(signed_wide_output[i] == wide_signed[i], true);
+        stats.accumulate(unsigned_wide_output[i] == wide_unsigned[i], true);
+    }
+    nk_i32_t unchanged = 42;
+    kernel(source, nk_f64_k, 1, &unchanged, nk_f32_k);
+    stats.accumulate(unchanged, (nk_i32_t)42);
+    kernel(&unchanged, nk_i32_k, 1, signed_output, nk_i8_k);
+    stats.accumulate(signed_output[0], expected_signed[0]);
+    return stats;
+}
+
 void test_casts() {
     error_stats_section_t check;
 
     check.section("Type Casts Serial", nk_cap_serial_k);
+    check("cast_truncate_serial", test_cast_truncate, nk_cast_truncate_serial);
+    check("cast_truncate", test_cast_truncate, nk_cast_truncate);
     check("cast_bf16_to_f32_serial", test_cast<bf16_t, f32_t>, nk_cast_serial);
     check("cast_f32_to_bf16_serial", test_cast<f32_t, bf16_t>, nk_cast_serial);
     check("cast_e4m3_to_f32_serial", test_cast<e4m3_t, f32_t>, nk_cast_serial);

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -256,6 +256,185 @@ def test_capabilities_list():
         nk.disable_capability("neon")
 
 
+@pytest.mark.skipif(not numpy_available, reason="NumPy required")
+@pytest.mark.parametrize("source_dtype", ["float16", "float32", "float64"])
+@pytest.mark.parametrize("target_dtype", ["int8", "uint8", "int16", "uint16", "int32", "uint32", "int64", "uint64"])
+def test_astype_truncate_numpy_oracle(source_dtype, target_dtype):
+    """NumPy truncates finite in-range values; Python integers clamp exact 64-bit bounds."""
+    limits = np.iinfo(target_dtype)
+    with np.errstate(over="ignore", invalid="ignore"):
+        bounds = np.array([limits.min, limits.max], dtype=source_dtype)
+        source = np.concatenate(
+            [
+                np.array(
+                    [
+                        -300.9,
+                        -128.9,
+                        -2.5,
+                        -1.9,
+                        -1.5,
+                        -0.5,
+                        -0.0,
+                        0.5,
+                        1.5,
+                        1.9,
+                        2.5,
+                        127.9,
+                        255.9,
+                        300.9,
+                        np.nan,
+                        np.inf,
+                        -np.inf,
+                    ],
+                    dtype=source_dtype,
+                ),
+                bounds,
+                np.nextafter(bounds, -np.inf),
+                np.nextafter(bounds, np.inf),
+            ]
+        )
+    # Never cast NaN/inf/out-of-range floats with NumPy: those results are platform-dependent.
+    expected = np.array(
+        [
+            (
+                0
+                if np.isnan(x)
+                else (
+                    limits.max
+                    if x == np.inf
+                    else limits.min if x == -np.inf else min(limits.max, max(limits.min, int(np.trunc(x))))
+                )
+            )
+            for x in source
+        ],
+        dtype=target_dtype,
+    )
+    result = nk.astype(source, target_dtype, rounding="truncate")
+    np.testing.assert_array_equal(np.asarray(result), expected)
+    output = np.empty(source.shape, dtype=target_dtype)
+    assert nk.astype(source, target_dtype, rounding="truncate", out=output) is output
+    np.testing.assert_array_equal(output, expected)
+    finite = source[np.isfinite(source)]
+    in_range = np.array([limits.min <= int(np.trunc(x)) <= limits.max for x in finite])
+    np.testing.assert_array_equal(
+        np.asarray(nk.astype(finite[in_range], target_dtype, rounding="truncate")),
+        finite[in_range].astype(target_dtype),
+    )
+
+
+@pytest.mark.skipif(not numpy_available, reason="NumPy required")
+@pytest.mark.parametrize(
+    "layout", ["contiguous", "transpose", "reverse", "slice", "broadcast", "scalar", "empty", "rank5"]
+)
+def test_astype_truncate_layout_and_default(layout):
+    source = np.linspace(-20.5, 300.5, 120, dtype=np.float32).reshape(2, 4, 5, 3)
+    source = {
+        "contiguous": source,
+        "transpose": source.transpose(3, 1, 0, 2),
+        "reverse": source[::-1, :, ::-1, :],
+        "slice": source[:, ::2, :, ::2],
+        "broadcast": np.broadcast_to(source[0, 0, 0, 0], (2, 3, 4)),
+        "scalar": np.array(1.9, dtype=np.float32),
+        "empty": source[:, :0],
+        "rank5": source.reshape(2, 2, 2, 5, 3),
+    }[layout]
+    expected = np.clip(np.trunc(source), 0, 255).astype(np.uint8)
+    output = np.empty(source.shape, dtype=np.uint8)
+    result = nk.astype(source, "u1", rounding="truncate")
+    assert result.shape == source.shape
+    np.testing.assert_array_equal(np.asarray(result), expected)
+    assert nk.astype(source, "uint8", rounding="truncate", out=output) is output
+    np.testing.assert_array_equal(output, expected)
+    clipped = np.clip(source, 0, 255)
+    np.testing.assert_array_equal(
+        np.asarray(nk.astype(clipped, "uint8", rounding="truncate")), clipped.astype(np.uint8)
+    )
+    nearest = np.clip(np.rint(source), 0, 255).astype(np.uint8)
+    np.testing.assert_array_equal(np.asarray(nk.astype(source, "uint8")), nearest)
+    np.testing.assert_array_equal(np.asarray(nk.astype(source, "uint8", rounding="nearest_even")), nearest)
+
+
+@pytest.mark.skipif(not numpy_available, reason="NumPy required")
+def test_astype_truncate_validation():
+    source = np.array([-1.9, 0.5, 1.9, 2.5], dtype=np.float32)
+    for rounding, error in [
+        (None, TypeError),
+        (1, TypeError),
+        (b"truncate", TypeError),
+        ("floor", ValueError),
+        ("truncate\0", ValueError),
+    ]:
+        with pytest.raises(error, match="rounding"):
+            nk.astype(source, "int32", rounding=rounding)
+    for src, dtype in [
+        (source, "float64"),
+        (source.astype(np.int32), "int8"),
+        (source.astype(np.complex64), "int8"),
+        (source, "int4"),
+        (source, "uint4"),
+        (source, "uint1"),
+    ]:
+        with pytest.raises(ValueError, match="truncate"):
+            nk.astype(src, dtype, rounding="truncate")
+    for output in [source.view(np.int32), source[::-1].view(np.int32)]:
+        with pytest.raises(ValueError):
+            nk.astype(source, "int32", rounding="truncate", out=output)
+    backing = np.arange(8, dtype=np.float32)
+    with pytest.raises(ValueError, match="overlap"):
+        nk.astype(backing[:4], "int32", rounding="truncate", out=backing[2:6].view(np.int32))
+    for output in [np.empty(3, dtype=np.int32), np.empty(4, dtype=np.int16), np.empty(8, dtype=np.int32)[::2]]:
+        with pytest.raises((ValueError, TypeError)):
+            nk.astype(source, "int32", rounding="truncate", out=output)
+    output = np.empty(4, dtype=np.int32)
+    output.flags.writeable = False
+    with pytest.raises((ValueError, BufferError)):
+        nk.astype(source, "int32", rounding="truncate", out=output)
+    tensor = nk.empty(source.shape, dtype="int32")
+    assert nk.astype(source, "int32", rounding="truncate", out=tensor) is tensor
+    np.testing.assert_array_equal(np.asarray(tensor), source.astype(np.int32))
+
+
+@pytest.mark.skipif(not ml_dtypes_available, reason="ml_dtypes required")
+@pytest.mark.parametrize("source_dtype", ["bfloat16", "float8_e4m3fn", "float8_e5m2", "float6_e2m3fn", "float6_e3m2fn"])
+@pytest.mark.parametrize("target_dtype", ["int8", "uint8", "int16", "uint16", "int32", "uint32", "int64", "uint64"])
+def test_astype_truncate_minifloats(source_dtype, target_dtype):
+    # Cast the actual quantized values with NumPy, rather than assuming the original fractions survive.
+    source = np.array([-1.9, -1.5, -0.5, 0.5, 1.5, 1.9, 2.5], dtype=getattr(ml_dtypes, source_dtype))
+    reference = source.astype(np.float64)
+    if np.iinfo(target_dtype).min == 0:
+        reference = np.maximum(reference, 0)
+    expected = reference.astype(target_dtype)
+    for inputs, reference_values in [(source, expected), (source[::-1], expected[::-1]), (nk.Tensor(source), expected)]:
+        output = np.empty(source.shape, dtype=target_dtype)
+        assert nk.astype(inputs, target_dtype, rounding="truncate", out=output) is output
+        np.testing.assert_array_equal(output, reference_values)
+
+
+@pytest.mark.skipif(not numpy_available, reason="NumPy required")
+@pytest.mark.parametrize("target_dtype", ["int8", "uint8", "int16", "uint16", "int32", "uint32", "int64", "uint64"])
+def test_astype_nearest_even_remains_default(target_dtype):
+    source = np.array([-np.inf, np.nan, -2.5, -1.9, -1.5, -0.5, 0.5, 1.5, 1.9, 2.5, np.inf])
+    limits = np.iinfo(target_dtype)
+    expected = np.array(
+        [limits.min, 0, max(limits.min, -2), max(limits.min, -2), max(limits.min, -2), 0, 0, 2, 2, 2, limits.max],
+        dtype=target_dtype,
+    )
+    np.testing.assert_array_equal(np.asarray(nk.astype(source, target_dtype)), expected)
+    np.testing.assert_array_equal(np.asarray(nk.astype(source, target_dtype, rounding="nearest_even")), expected)
+
+
+@pytest.mark.skipif(not numpy_available, reason="NumPy required")
+@pytest.mark.parametrize("target_dtype", ["int16", "uint16", "int32", "uint32", "int64", "uint64"])
+def test_astype_truncate_unaligned_buffers(target_dtype):
+    # Native-format memoryviews avoid NumPy's '=d' buffer format, which the existing parser rejects.
+    source = memoryview(bytearray(17 * 8 + 1))[1:].cast("d")
+    np.asarray(source)[:] = np.linspace(0.5, 16.5, 17)
+    dtype = np.dtype(target_dtype)
+    output = memoryview(bytearray(17 * dtype.itemsize + 1))[1:].cast(dtype.char)
+    assert nk.astype(source, target_dtype, rounding="truncate", out=output) is output
+    np.testing.assert_array_equal(np.asarray(output), np.asarray(source).astype(target_dtype))
+
+
 @pytest.mark.skipif(not numpy_available, reason="NumPy is not installed")
 @pytest.mark.parametrize(
     "function, expected_error, args, kwargs",


### PR DESCRIPTION
Implements the explicit rounding mode requested in #377:

```python
nk.astype(values, "uint8", rounding="truncate", out=output)
```

For example, `1.9` becomes `1` in this mode. Omitted rounding and `rounding="nearest_even"` preserve the existing behavior. Truncation saturates overflow/infinities and maps NaN to zero, while retaining the existing strided-input, shape, output-buffer, and overlap checks.

This draft proposes a separate native `nk_cast_truncate` entry point and dispatch kind, initially backed by a portable serial kernel. Python accepts real floating sources and signed/unsigned 8–64-bit integer destinations; packed outputs and other conversions are rejected. No SIMD speedup is claimed. Feedback on the native API, serial baseline, and packed-output scope would help settle the implementation before marking it ready.

Validation on Apple Silicon / Python 3.12:

- 942 tensor tests passed, 3 free-threaded cases skipped; 96 cast tests also passed with only serial capability enabled.
- Independent rerun: 96 cast tests passed, plus the native shared-library cast suite.
- Native static/shared cast suites and a UBSan/float-cast-overflow boundary harness passed. Cases include 64-bit limits, nonfinite inputs, unaligned buffers, batch tails, and rounding-state preservation.
- Changed C/C++ formatting and Python test lint/format pass. Existing unrelated repository/stub formatting and Ruff findings remain.
- Four benchmark registrations execute; this was a smoke test, not a performance comparison.

ASan remains unverified because its local runtime stalled before `main`. Other architectures, OSes, language bindings, and the full repository CI matrix were not validated locally.

AI assistance: OpenAI Codex (GPT-6) was used for investigation, implementation, review, and testing.
